### PR TITLE
ci(changelog): pull-rebase before pushing changelog commit

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,20 +1,18 @@
 name: Update Changelog
 
 on:
-  # fire when a PR into `main` is closed (merged == true)
   pull_request:
     types: [closed]
     branches: [main]
-  # fire again when the resulting squash-merge commit lands on `main`
   push:
     branches: [main]
 
 permissions:
-  contents: write   # allow the workflow to push the changelog
+  contents: write
 
 jobs:
   build:
-    # run if the PR was merged _or_ the event is a push to main
+    # run if: merged PR → main  OR  direct push → main
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
 
@@ -32,15 +30,20 @@ jobs:
         run: conventional-changelog -p angular -i docs/handoff/changelog.md -s
 
       - name: Commit changelog if changed
-        id: diff
+        id: commit
         run: |
-          git diff --quiet docs/handoff/changelog.md || {
+          if git diff --quiet docs/handoff/changelog.md ; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
             git config user.name  "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add docs/handoff/changelog.md
             git commit -m "chore: update changelog [skip ci]"
-          }
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Push commit
-        if: steps.diff.outcome == 'success'
-        uses: ad-m/github-push-action@v0.8.0
+        if: steps.commit.outputs.has_changes == 'true'
+        run: |
+          git pull --rebase origin main
+          git push origin HEAD:main


### PR DESCRIPTION
- Pull --rebase before pushing the changelog commit to avoid
  “fetch first” rejections when `main` moves mid-job.
- Replaces GitHub-push action with a plain git push after rebase.
- Still skips the push entirely when `has_changes` is false.