### PR TITLE
docs(license): add MIT license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 ZeroSumQuant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/handoff/2025-05-13-2.md
+++ b/docs/handoff/2025-05-13-2.md
@@ -1,0 +1,31 @@
+# Handoff Report - 2025-05-13 (Part 2)
+
+## Summary
+
+Added the MIT LICENSE file to the repository as specified in issue #38. This completes the documentation requirements mentioned in several handoff documents and clarifies how others can use, modify, and distribute the code.
+
+## Tasks Completed
+
+1. Created branch `claude-2025-05-13-add-license` for adding the MIT license file
+2. Added standard MIT license file to the project root with ZeroSumQuant as the copyright holder
+3. Ran linting and tests to ensure code quality remained intact
+4. Updated task log and created handoff documentation
+5. Prepared changes for PR to close issue #38
+
+## Issues Encountered
+
+None. This was a straightforward documentation update.
+
+## Next Steps
+
+1. Commit and push changes to the repository
+2. Create a pull request to close issue #38
+3. Continue addressing other open issues, focusing on:
+   - Issue #16 (Implement AutoGen agent orchestration in luca.py)
+   - Issue #28 (Create agent orchestration architecture document)
+   - Issue #31 (Modernize dependency management with Poetry)
+
+## References
+
+- [Issue #38: Add LICENSE file](https://github.com/ZeroSumQuant/luca-dev-assistant/issues/38)
+- [README.md](https://github.com/ZeroSumQuant/luca-dev-assistant/blob/main/README.md) - Already indicated MIT license in the License section

--- a/docs/task_log.md
+++ b/docs/task_log.md
@@ -260,3 +260,10 @@
   - Created detailed handoff document at `docs/handoff/2025-05-13-1.md`
   - Provided clear documentation of all changes made during the session
   - Ensured all project guidelines for documentation were followed
+- **11:00 pm — License addition** – added MIT license file to repository:
+  - Created branch `claude-2025-05-13-add-license` for license addition
+  - Added standard MIT license file with ZeroSumQuant as copyright holder
+  - Verified license matches project intent as documented in README.md
+  - Ran linting and tests to ensure code quality
+  - Created handoff document at `docs/handoff/2025-05-13-2.md`
+  - Prepared changes to address issue #38


### PR DESCRIPTION
## Summary
- Add standard MIT license file to repository
- Document copyright holder as ZeroSumQuant
- Update task log and create handoff document

Closes #38

🤖 Generated with [Claude Code](https://claude.ai/code)