### PR TITLE
fix(deps): sync autogen packages to 0.5.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@ pytest-forked==1.6.0  # May be needed for thread method in CI
 pytest-asyncio==0.24.0  # For async test support in MCP tests
 
 # AutoGen Stack - current versions
-autogen-agentchat==0.5.6
-autogen-ext[docker]==0.5.6
+autogen-agentchat==0.5.7
+autogen-ext[docker]==0.5.7
 
 # UI - Let's try a newer streamlit version
 streamlit==1.43.0  # This was before the pillow<11 requirement


### PR DESCRIPTION
## Summary
- Sync all autogen packages to version 0.5.7 to fix dependency conflicts

## Details
Dependabot PR #94 was failing because it only updated `autogen-ext[docker]` to 0.5.7, but all autogen packages have strict version dependencies on `autogen-core`. They must all be at the same version.

This PR updates both:
- `autogen-agentchat`: 0.5.6 → 0.5.7
- `autogen-ext[docker]`: 0.5.6 → 0.5.7

## Test plan
- [x] CI passes
- [x] All tests pass with 97.34% coverage
- [x] Dependabot PR #94 should now pass CI after rebasing

Fixes dependency conflict in #94