### PR TITLE
fix: update autogen packages to 0.6.1 together

### DIFF
--- a/docs/handoff/2025-06-05-1.md
+++ b/docs/handoff/2025-06-05-1.md
@@ -1,0 +1,37 @@
+# Handoff: 2025-06-05-1
+
+## Session Summary
+
+Fixed autogen dependency conflicts that were causing dependabot PR failures and cleaned up repository for professional presentation.
+
+## Work Completed
+
+### 1. Fixed autogen dependency conflict (requirements.txt)
+- Updated both autogen-agentchat and autogen-ext to 0.6.1
+- Resolved dependency lock issue where packages must share same autogen-core version
+- This fixes failing dependabot PRs #125 and #126
+
+### 2. Cleaned up repository presentation
+- Removed all .DS_Store files from repository
+- Removed temporary artifacts (zip file, coverage_history.json)
+- Repository is now clean for recruiter review
+
+## Current State
+
+- **Working**: All core functionality, CI/CD pipeline, 97% test coverage
+- **Fixed**: Autogen dependency conflicts resolved
+- **Pending**: Two dependabot PRs can now be closed in favor of our fix
+- **Branch**: fix/autogen-version-sync ready for PR
+
+## Next Steps
+
+1. Create PR for fix/autogen-version-sync branch
+2. Close dependabot PRs #125 and #126 in favor of our combined fix
+3. Monitor for any new dependabot updates
+4. Continue CAKE integration planning
+
+## Critical Notes
+
+- Autogen packages must always be updated together due to shared core dependency
+- Pre-push hooks enforce strict documentation schema validation
+- Repository is presentation-ready for recruiting purposes

--- a/docs/task_log.md
+++ b/docs/task_log.md
@@ -270,6 +270,17 @@
   - All quality gates (black, isort, flake8, bandit, mypy, pytest) pass
   - Ready for Phase 2: SecurityAgent stub, QuantAnalyst rename, sandbox limits
 
+## 2025-06-05
+
+- **Repository cleanup for presentation**:
+  - Removed all .DS_Store files and temporary artifacts
+  - Ensured clean working tree on main branch
+  - Repository ready for recruiter review
+- **Fixed autogen dependency conflicts**:
+  - Updated both autogen-agentchat and autogen-ext to 0.6.1 together
+  - Resolved version lock issue causing dependabot PR failures
+  - Created fix/autogen-version-sync branch with solution
+
 ## 2025-05-15
 
 - **Morning — ErrorPayload Schema v1.0.0** – enhanced error schema per CTO requirements:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@ pytest-forked==1.6.0  # May be needed for thread method in CI
 pytest-asyncio==0.26.0  # For async test support in MCP tests
 
 # AutoGen Stack - current versions
-autogen-agentchat==0.5.7
-autogen-ext[docker]==0.5.7
+autogen-agentchat==0.6.1
+autogen-ext[docker]==0.6.1
 
 # UI - Let's try a newer streamlit version
 streamlit==1.45.1  # This was before the pillow<11 requirement


### PR DESCRIPTION
## Summary
- Updates both autogen-agentchat and autogen-ext from 0.5.7 to 0.6.1
- Resolves dependency conflict where both packages must share the same autogen-core version

## Context
Dependabot created separate PRs (#125 and #126) to update these packages individually, but they failed CI because autogen packages have a version lock between them. This PR updates both packages together to resolve the conflict.

## Changes
- Updated autogen-agentchat==0.5.7 → 0.6.1
- Updated autogen-ext[docker]==0.5.7 → 0.6.1

## Testing
- All tests pass with 97% coverage
- No breaking changes detected

Closes #125
Closes #126