### PR TITLE
fix(typing): remove mypy exclusion for store.py (#55)

### DIFF
--- a/.config/mypy.ini
+++ b/.config/mypy.ini
@@ -18,5 +18,3 @@ ignore_errors = True
 [mypy-luca_core.error.handler]
 ignore_errors = True
 
-[mypy-luca_core.context.store]
-ignore_errors = True

--- a/docs/handoff/2025-06-08-5.md
+++ b/docs/handoff/2025-06-08-5.md
@@ -1,0 +1,32 @@
+# Handoff: 2025-06-08-5
+
+## Session Summary
+Resolved Issue #55 (CI-DEBT-#4: type hygiene for store.py) by removing mypy exclusions from the configuration. The file already had proper type annotations and passed all type checks, so only the configuration update was needed.
+
+## Work Completed
+
+### 1. Mypy Configuration Cleanup (Issue #55)
+- Removed `ignore_errors = True` for `luca_core.context.store` from `.config/mypy.ini`
+- Verified store.py passes mypy checks in both standard and strict modes
+- Confirmed no `type: ignore` comments exist in the file
+- Ran all context store tests to ensure functionality remains intact (7/7 tests pass)
+
+## Current State
+- **Working**: Type checking for store.py is now enabled and passing
+- **Broken**: None
+- **Blocked**: None
+
+## Next Steps
+- Close Issue #55 as completed
+- Next priority: Issue #54 (CI-DEBT-#3: Fix legacy async tests)
+- After CI debt: Issue #59 (PH1-4: Improved logging and monitoring)
+
+## Critical Notes
+- The issue was simpler than expected - the code was already properly typed
+- Only the mypy configuration needed updating
+- This demonstrates good code quality in the existing implementation
+
+## Files Modified
+- `.config/mypy.ini`: Removed store.py exclusion
+- `docs/task_log.md`: Added entry for Issue #55
+- `docs/handoff/2025-06-08-5.md`: Created this handoff document

--- a/docs/task_log.md
+++ b/docs/task_log.md
@@ -17,6 +17,13 @@
 - **Issues**: Pre-commit hooks required fixing test imports and formatting
 - **Next**: None - feature complete
 
+- **Type Hygiene for store.py (Issue #55)**: Removed mypy exclusions and verified type safety
+  - Removed `ignore_errors = True` for `luca_core.context.store` from `.config/mypy.ini`
+  - Verified store.py passes all mypy checks including strict mode
+  - No type: ignore comments needed in the file
+  - All tests pass (7/7 in test_context_store.py)
+  - File already had proper type annotations throughout
+
 - **5:00 am — Test suite performance optimization** – Achieved 6.5x speedup (36s → 5.6s):
   - Replaced sleep-based waits with direct method calls in SQLite backup tests
   - Reduced sandbox timeout test from 1s to 0.1s while maintaining test validity


### PR DESCRIPTION
## Summary
- Removes the `ignore_errors = True` configuration for `luca_core.context.store` from mypy.ini
- The file already has proper type annotations and passes all mypy checks
- This completes the type hygiene cleanup for store.py

## Test plan
- [x] Verified store.py passes mypy checks in standard mode
- [x] Verified store.py passes mypy checks in strict mode
- [x] Confirmed no `type: ignore` comments exist in the file
- [x] All context store tests pass (7/7)
- [x] Overall test coverage maintained at 95.51%

## Changes
- Removed mypy exclusion from `.config/mypy.ini`
- Updated task log with completion of Issue #55
- Created handoff document

Closes #55

🤖 Generated with [Claude Code](https://claude.ai/code)