### PR TITLE
fix(tests): re-enable async tests in test_mcp_integration.py (#54)

### DIFF
--- a/.config/pytest.ini
+++ b/.config/pytest.ini
@@ -1,8 +1,7 @@
 [pytest]
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
-addopts = -p no:warnings --ignore=tests/test_mcp_integration.py
-# temporary skip of legacy async tests — see CI-DEBT-#3
+addopts = -p no:warnings
 markers =
     real_exec: tests requiring real function execution (not mocked)
     skip_ci: mark test to skip in CI environment (for known issues)

--- a/coverage_history.json
+++ b/coverage_history.json
@@ -99,6 +99,11 @@
       "timestamp": "2025-06-08T07:11:50.427558+00:00",
       "percentage": 96.0,
       "commit_sha": "b7e098f"
+    },
+    {
+      "timestamp": "2025-06-09T02:06:48.186193+00:00",
+      "percentage": 96.0,
+      "commit_sha": "cb87040"
     }
   ]
 }

--- a/docs/handoff/2025-06-08-6.md
+++ b/docs/handoff/2025-06-08-6.md
@@ -1,0 +1,40 @@
+# Handoff: 2025-06-08-6
+
+## Session Summary
+Resolved Issue #54 (CI-DEBT-#3: Fix legacy async tests) by re-enabling the test_mcp_integration.py tests that were previously ignored due to async compatibility issues. Fixed a failing test that was checking for absolute file paths.
+
+## Work Completed
+
+### 1. Fixed Async Test Compatibility (Issue #54)
+- Identified the root cause: test was using absolute path `/path/to/script.py` which triggered validation error
+- Changed to relative path `./mcp_servers/test_script.py` in test configuration
+- Added mock for `validate_file_path` function to bypass file existence check in tests
+- Fixed the failing `test_connect_to_stdio_server` test
+
+### 2. Re-enabled MCP Integration Tests
+- Removed `--ignore=tests/test_mcp_integration.py` from `.config/pytest.ini`
+- Verified all 27 tests pass (1 test skipped for full integration)
+- Confirmed pytest-asyncio 0.24.0 is properly installed and working
+
+## Current State
+- **Working**: All async tests in test_mcp_integration.py are now running and passing
+- **Broken**: None
+- **Blocked**: None
+
+## Next Steps
+- Close Issue #54 as completed
+- Next priorities in order:
+  1. Issue #59: PH1-4: Improved logging and monitoring
+  2. Issue #58: PH1-3: Basic authentication and session management
+  3. Issue #57: PH1-2: Streamlit status panels
+
+## Critical Notes
+- The CI environment skip is still in place for MCP tests (when CI=true)
+- One test requires RUN_MCP_INTEGRATION=1 environment variable for full integration testing
+- All async fixtures are working properly with pytest-asyncio
+
+## Files Modified
+- `tests/test_mcp_integration.py`: Fixed test_connect_to_stdio_server with validation mocking
+- `.config/pytest.ini`: Removed test ignore flag
+- `docs/task_log.md`: Added entry for Issue #54
+- `docs/handoff/2025-06-08-6.md`: Created this handoff document

--- a/docs/task_log.md
+++ b/docs/task_log.md
@@ -2,6 +2,20 @@
 
 ## 2025-06-08
 
+- **Fix Legacy Async Tests (Issue #54)**: Re-enabled test_mcp_integration.py tests
+  - Fixed failing test by mocking file path validation in test_connect_to_stdio_server
+  - Changed absolute path to relative path in test configuration
+  - Added validation mock to bypass file existence check in tests
+  - Removed `--ignore=tests/test_mcp_integration.py` from pytest.ini
+  - All 27 tests now pass (1 skipped for full integration)
+
+- **Type Hygiene for store.py (Issue #55)**: Removed mypy exclusions and verified type safety
+  - Removed `ignore_errors = True` for `luca_core.context.store` from `.config/mypy.ini`
+  - Verified store.py passes all mypy checks including strict mode
+  - No type: ignore comments needed in the file
+  - All tests pass (7/7 in test_context_store.py)
+  - File already had proper type annotations throughout
+
 - **Changes**: Implemented comprehensive input validation (Issue #27)
   - Created `luca_core/validation/validators.py` with validation functions for paths, URLs, prompts, SQL, JSON, shell commands
   - Modified `tools/file_io.py` to add path validation and file size limits
@@ -16,13 +30,6 @@
 - **Coverage**: 95.78% (increased from baseline)
 - **Issues**: Pre-commit hooks required fixing test imports and formatting
 - **Next**: None - feature complete
-
-- **Type Hygiene for store.py (Issue #55)**: Removed mypy exclusions and verified type safety
-  - Removed `ignore_errors = True` for `luca_core.context.store` from `.config/mypy.ini`
-  - Verified store.py passes all mypy checks including strict mode
-  - No type: ignore comments needed in the file
-  - All tests pass (7/7 in test_context_store.py)
-  - File already had proper type annotations throughout
 
 - **5:00 am — Test suite performance optimization** – Achieved 6.5x speedup (36s → 5.6s):
   - Replaced sleep-based waits with direct method calls in SQLite backup tests

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -112,7 +112,8 @@ async def mock_stdio_client():
     response_mock.tools = [tool1, tool2]
     session_mock.call = AsyncMock(return_value=response_mock)
 
-    # Create a mock for stdio_client that is an awaitable function that returns the session
+    # Create a mock for stdio_client that is an awaitable function that returns
+    # the session
     async def mock_stdio_client_func(*args, **kwargs):
         return session_mock
 
@@ -139,7 +140,8 @@ async def mock_http_client():
     response_mock.tools = [tool1]
     session_mock.call = AsyncMock(return_value=response_mock)
 
-    # Create a mock for http_client that is an awaitable function that returns the session
+    # Create a mock for http_client that is an awaitable function that returns
+    # the session
     async def mock_http_client_func(*args, **kwargs):
         return session_mock
 
@@ -203,21 +205,26 @@ class TestMCPClientManager:
         async def mock_stdio_client(*args, **kwargs):
             return session_mock
 
-        # Create a config for stdio server
+        # Create a config for stdio server with relative path
         config = MCPServerConfig(
             name="test_stdio",
             type="stdio",
-            script_path="/path/to/script.py",
+            script_path="./mcp_servers/test_script.py",
             description="Test stdio server",
         )
 
-        # Patch the stdio_client and connect to the server
+        # Patch the stdio_client and validation, then connect to the server
         with patch("tools.mcp_client.stdio_client", mock_stdio_client):
-            # Also patch the ListToolsRequest to return a valid request object
-            with patch.object(
-                types, "ListToolsRequest", return_value=make_list_tools_request()
+            # Mock the file validation to allow test paths
+            with patch(
+                "tools.mcp_client.validate_file_path",
+                return_value="./mcp_servers/test_script.py",
             ):
-                result = await mcp_client.connect_to_server(config)
+                # Also patch the ListToolsRequest to return a valid request object
+                with patch.object(
+                    types, "ListToolsRequest", return_value=make_list_tools_request()
+                ):
+                    result = await mcp_client.connect_to_server(config)
 
         # Verify the result
         assert result is True
@@ -958,7 +965,10 @@ class TestMCPClientAdvanced:
 # Special integration test that actually runs the filesystem server
 @pytest.mark.skipif(
     os.environ.get("RUN_MCP_INTEGRATION") != "1",
-    reason="Full integration test requires actual filesystem server and RUN_MCP_INTEGRATION=1",
+    reason=(
+        "Full integration test requires actual filesystem server "
+        "and RUN_MCP_INTEGRATION=1"
+    ),
 )
 class TestMCPFullIntegration:
     """Full integration test with actual MCP server"""


### PR DESCRIPTION
## Summary
- Re-enables the previously ignored async tests in test_mcp_integration.py
- Fixes failing test by properly mocking file path validation
- Removes the pytest ignore flag that was blocking these tests

## Test plan
- [x] Fixed test_connect_to_stdio_server by mocking validate_file_path
- [x] Changed absolute path to relative path in test configuration
- [x] Removed `--ignore=tests/test_mcp_integration.py` from pytest.ini
- [x] Verified all 27 tests pass (1 skipped for full integration)
- [x] Confirmed pytest-asyncio 0.24.0 is properly installed
- [x] All quality gates pass

## Changes
- Modified test to use relative path instead of absolute path
- Added validation mock to bypass file existence check in tests
- Removed pytest ignore flag from `.config/pytest.ini`
- Updated task log and created handoff document

## Notes
- The CI environment skip is still in place for MCP tests (when CI=true)
- One test requires RUN_MCP_INTEGRATION=1 for full integration testing

Closes #54

🤖 Generated with [Claude Code](https://claude.ai/code)